### PR TITLE
Update the tutorial to redirect to /start

### DIFF
--- a/tutorials/vaadin-quick-start/content.adoc
+++ b/tutorials/vaadin-quick-start/content.adoc
@@ -26,7 +26,7 @@ This tutorial assumes you have the following set up on your computer:
 
 == Download and import the app starter
 
-https://vaadin.com/vaadincom/start-service/latest/project-base?techStack=spring["Download starter", class="button button--bordered"]
+https://vaadin.com/start/latest/project-base["Download starter", class="button button--bordered"]
 
 Once you have the starter downloaded, unzip the file and open it in your IDE.  Ensure you can start the project by running the `spring-boot:run` Maven target. 
 


### PR DESCRIPTION
Direct downloads from the REST endpoint on the browser are not supported.