### PR TITLE
fix typo in using-web-components-in-angular/content.adoc

### DIFF
--- a/tutorials/using-web-components-in-angular/content.adoc
+++ b/tutorials/using-web-components-in-angular/content.adoc
@@ -101,7 +101,7 @@ Then, include the loader and an optional import for the ES5 compatibility script
 <script>
   if (!window.customElements{document.write('<!--');}
 </script>
-<scripsrc="webcomponents/custom-elements-es5-apter.js"></script>
+<script src="webcomponents/custom-elements-es5-apter.js"></script>
 <!-- ! DO NOT REMOVE THIS COMMENT, WE NEED ITS CLOSING MARKER -->
 ----
 


### PR DESCRIPTION
fixed the typo mentioned in the referenced issue #136 .