### PR TITLE
Designer tutorial. Removed new custom tags

### DIFF
--- a/learn/tutorials/vaadin-designer-tutorial/content.adoc
+++ b/learn/tutorials/vaadin-designer-tutorial/content.adoc
@@ -1,7 +1,7 @@
 = Vaadin Designer Tutorial
 
 :type: text
-:tags: Component, CSS, Java, Templating, Web Components, Layout, Web GUI, WYSIWYG, Designer
+:tags: Component, CSS, Java, Templating, Web Components, Layout
 :description: This tutorial shows the first steps with Vaadin Designer. Learn to create components and views, and how to connect to a backend.
 :repo: https://github.com/vaadin-learning-center/VaadinDesigner_01_Basics
 :linkattrs:


### PR DESCRIPTION
I added new custom tags in the last PR, as I thought they were free form and used for SEO and such. Apparently they are string references to objects and causing problems. This patch removes the custom ones that I added.